### PR TITLE
Refactor CI & CMake Setup: Rename Targets, Update Checkout, and Improve Test Script

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -12,6 +12,12 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+      - name: Upgrade compiler to GCC 13
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++-13 gcc-13
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 60
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 60
       - name: Install Dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -12,12 +12,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-      - name: Upgrade compiler to GCC 13
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y g++-13 gcc-13
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 60
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 60
       - name: Install Dependencies
         run: |
           sudo apt-get update

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,24 +24,21 @@ file(GLOB TEST_SOURCES
 set(SOURCES ${CORE_SOURCES})
 
 # Create Library
-add_library(algorithm ${SOURCES})
+add_library(clavis_algorithm ${SOURCES})
 
 # Google Test Setup
 find_package(GTest REQUIRED)
 enable_testing()
 
 # Test Execution File
-add_executable(algorithm_test ${TEST_SOURCES})
+add_executable(clavis_algorithm_test ${TEST_SOURCES})
 
 # Include Directories
-target_include_directories(algorithm_test PRIVATE
+target_include_directories(clavis_algorithm_test PRIVATE
   ${CMAKE_SOURCE_DIR}/src
-  ${CMAKE_SOURCE_DIR}/src/graph
-  ${CMAKE_SOURCE_DIR}/src/data_structure
-  ${CMAKE_SOURCE_DIR}/src/sorting
 )
 
-target_link_libraries(algorithm_test algorithm GTest::GTest GTest::Main)
+target_link_libraries(clavis_algorithm_test clavis_algorithm GTest::GTest GTest::Main)
 
 # Register Test
-add_test(NAME AlgorithmTest COMMAND algorithm_test)
+add_test(NAME AlgorithmTest COMMAND clavis_algorithm_test)

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,52 +1,21 @@
 #!/bin/bash
+set -eux
 
-# Usage
-if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
-  echo "Usage: ./run_tests.sh [test_name]"
-  echo "Options:"
-  echo "  --help, -h    Show this help"
-  echo "  test_name     Run specific test (e.g., ./tests/sorting/shell_sort_test)"
-  exit 0
-fi
-
-# Create buiod directory
+# Create build directory if it doesn't exist
 if [ ! -d "build" ]; then
   mkdir build
 fi
 
-# Move to build directory
 cd build
 
 # CMake configuration
-cmake -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_STANDARD_REQUIRED=ON ..
+cmake -DCMAKE_BUILD_TYPE=Debug \
+      -DCMAKE_CXX_STANDARD=20 \
+      -DCMAKE_CXX_STANDARD_REQUIRED=ON \
+      ..
 
 # Build
-make
+cmake --build . -- -j"$(nproc)"
 
-# Test execution
-if [ -f "./algorithm_test" ]; then
-  if [ -n "$1" ]; then
-    # Get the base name and remove all extensions
-    base_name=$(basename "$1" | sed 's/\.[^.]*$//')
-    
-    # Convert to CamelCase
-    # First, if there's no underscore, capitalize all parts
-    if [[ $base_name != *"_"* ]]; then
-      test_suite=$(echo "$base_name" | sed -r 's/(^|_)([a-z])/\U\2/g')"Test"
-    else
-      # Otherwise, handle snake_case conversion
-      test_suite=$(echo "$base_name" | perl -pe 's/(^|_)([a-z])/\u$2/g')"Test"
-    fi
-    
-    echo "Input path: $1"
-    echo "Base name: $base_name"
-    echo "Test suite: $test_suite"
-    
-    # Run tests with more complete output
-    ./algorithm_test --gtest_filter="$test_suite.*" --gtest_also_run_disabled_tests
-  else
-    ./algorithm_test
-  fi
-else
-  echo "Test executable not found"
-fi
+# Run tests via CTest
+GTEST_COLOR=1 ctest --verbose --output-on-failure

--- a/src/data_structure/binary_search_tree.hpp
+++ b/src/data_structure/binary_search_tree.hpp
@@ -2,6 +2,7 @@
 #define BINARY_SEARCH_TREE_HPP
 
 #include <concepts>
+#include <functional>
 #include <iostream>
 #include <memory>
 #include <optional>

--- a/src/graph/bfs.hpp
+++ b/src/graph/bfs.hpp
@@ -1,6 +1,7 @@
 #ifndef BFS_HPP
 #define BFS_HPP
 
+#include <algorithm>
 #include <concepts>
 #include <iostream>
 #include <queue>
@@ -107,7 +108,7 @@ public:
         current = parent[current];
       }
       path.push_back(start);
-      std::ranges::reverse(path);
+      std::reverse(path.begin(), path.end());
     }
 
     return path;

--- a/src/sorting/bubble_sort.hpp
+++ b/src/sorting/bubble_sort.hpp
@@ -1,9 +1,11 @@
 #ifndef BUBBLE_SORT_HPP
 #define BUBBLE_SORT_HPP
 
+#include <algorithm>
 #include <concepts>
-#include <version>
 #include <iostream>
+#include <vector>
+#include <version>
 
 #include "sorting_concepts.hpp"
 

--- a/src/sorting/heap_sort.hpp
+++ b/src/sorting/heap_sort.hpp
@@ -4,6 +4,7 @@
 #include <concepts>
 #include <iostream>
 #include <ranges>
+#include <vector>
 
 #include "sorting_concepts.hpp"
 

--- a/src/sorting/merge_sort.hpp
+++ b/src/sorting/merge_sort.hpp
@@ -1,6 +1,7 @@
 #ifndef MERGE_SORT_HPP
 #define MERGE_SORT_HPP
 
+#include <algorithm>
 #include <concepts>
 #include <iostream>
 #include <memory>
@@ -22,10 +23,15 @@ void merge(std::span<T> arr, size_t left, size_t mid, size_t right) {
       temp[k++] = std::move(arr[j++]);
     }
   }
-
-  std::ranges::move(arr.subspan(i, mid - i + 1), temp.begin() + k);
-  std::ranges::move(arr.subspan(j, right - j + 1), temp.begin() + k);
-  std::ranges::move(temp, arr.begin() + left);
+  /*
+   * Commented out because it causes errors in the CI environment.
+   ** std::ranges::move(arr.subspan(i, mid - i + 1), temp.begin() + k);
+   ** std::ranges::move(arr.subspan(j, right - j + 1), temp.begin() + k);
+   ** std::ranges::move(temp, arr.begin() + left);
+   */
+  std::move(arr.begin() + i, arr.begin() + i + (mid - i + 1), temp.begin() + k);
+  std::move(arr.begin() + j, arr.begin() + j + (right - j + 1), temp.begin() + k);
+  std::move(temp.begin(), temp.end(), arr.begin() + left);
 }
 
 template <Mergeable T>

--- a/src/sorting/merge_sort.hpp
+++ b/src/sorting/merge_sort.hpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <memory>
 #include <span>
+#include <vector>
 
 #include "sorting_concepts.hpp"
 

--- a/src/sorting/quick_sort.hpp
+++ b/src/sorting/quick_sort.hpp
@@ -4,6 +4,7 @@
 #include <concepts>
 #include <iostream>
 #include <ranges>
+#include <vector>
 
 #include "sorting_concepts.hpp"
 

--- a/src/sorting/radix_sort.hpp
+++ b/src/sorting/radix_sort.hpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <ranges>
 #include <span>
+#include <vector>
 
 template <std::integral T>
 void radixSort(std::vector<T>& arr) {

--- a/src/sorting/radix_sort.hpp
+++ b/src/sorting/radix_sort.hpp
@@ -1,9 +1,9 @@
 #ifndef RADIX_SORT_HPP
 #define RADIX_SORT_HPP
 
+#include <algorithm>
 #include <concepts>
 #include <iostream>
-#include <ranges>
 #include <span>
 #include <vector>
 
@@ -13,8 +13,11 @@ void radixSort(std::vector<T>& arr) {
   if (arr.empty()) {
     return;
   };
-
-  auto max = std::ranges::max(arr);
+  /*
+   * Commented out because it causes errors in the CI environment.
+   ** auto max = std::ranges::max(arr);
+   */
+  auto max = *std::max_element(arr.begin(), arr.end());
   std::span s{arr};
 
   for (T exp = 1; max / exp > 0; exp *= 10) {
@@ -33,7 +36,11 @@ void radixSort(std::vector<T>& arr) {
       output[count[idx] - 1] = *it;
       count[idx]--;
     }
-    std::ranges::move(output, arr.begin());
+    /*
+     * Commented out because it causes errors in the CI environment.
+     ** std::ranges::move(output, arr.begin());
+     */
+    std::move(output.begin(), output.end(), arr.begin());
     std::cout << "Radix sort complete" << std::endl;
   }
 }

--- a/src/sorting/shell_sort.hpp
+++ b/src/sorting/shell_sort.hpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <ranges>
 #include <span>
+#include <vector>
 
 #include "sorting_concepts.hpp"
 


### PR DESCRIPTION
This pull request includes multiple changes aimed at improving the build process, updating dependencies, and fixing issues in the codebase. The most important changes include renaming libraries and executables, updating CI configurations, and modifying sorting algorithms to address CI environment issues.

### Build and CI Improvements:
* [`.github/workflows/cpp-ci.yml`](diffhunk://#diff-1a17449ff46099224e99300c0f26a6ae2768dace00e14983a9fdb0b7cc4227a2L14-R14): Updated the `uses` version for `actions/checkout` from `v3` to `v4`.
* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL27-R44): Renamed the library from `algorithm` to `clavis_algorithm` and the test executable from `algorithm_test` to `clavis_algorithm_test`. Updated related CMake commands accordingly.
* [`scripts/run_tests.sh`](diffhunk://#diff-e8dc6c83e649729e8adbbe07864f184105d21b7511ee421a35cd201a4821e0d2R2-R21): Added `set -eux` for better debugging and error handling, and updated the script to use `ctest` for running tests instead of directly invoking the test executable.

### Code Improvements:
* [`src/graph/bfs.hpp`](diffhunk://#diff-3a4b361bf3976e77f349511ff7128ffa95605dd1f7439bf60d13a5c71a42b25dL110-R111): Replaced `std::ranges::reverse` with `std::reverse` to fix compatibility issues.
* Various sorting headers (`src/sorting/merge_sort.hpp`, `src/sorting/radix_sort.hpp`): Commented out usage of `std::ranges::move` due to CI environment issues and replaced with `std::move`. [[1]](diffhunk://#diff-75e84099436c21ca690a0951605349330e46c9d53ce915f38cee38474a2f54e3L24-R34) [[2]](diffhunk://#diff-5db0d4b5e267df2718e360bb06741c2baca09a08252e5640d7c5bfd01f2b697dL35-R43)

### Dependency Updates:
* Added missing includes for `<algorithm>` and `<vector>` in several header files to ensure proper functionality and compatibility. [[1]](diffhunk://#diff-c2a08f6c81ed7d7a3007c73f5cf45bd6a8dd4417492b07858c42adc56133da21R5) [[2]](diffhunk://#diff-3a4b361bf3976e77f349511ff7128ffa95605dd1f7439bf60d13a5c71a42b25dR4) [[3]](diffhunk://#diff-f43cca794ada53d812ca74097a1eb925f70986729261dee5895c9e2c15c1ee0aR4-R8) [[4]](diffhunk://#diff-ffabb94a8f5f7a9e75419de83bfa5ef14f7a632dd612b0f19e245cf418bf022aR7) [[5]](diffhunk://#diff-75e84099436c21ca690a0951605349330e46c9d53ce915f38cee38474a2f54e3R4-R9) [[6]](diffhunk://#diff-0b9131cf779cc81e70fbd7ffefae0a960ff8f8f4b62a241a3d9a52fd4f6f7dffR7) [[7]](diffhunk://#diff-5db0d4b5e267df2718e360bb06741c2baca09a08252e5640d7c5bfd01f2b697dR4-R20) [[8]](diffhunk://#diff-980b90175ca5a0691e3874f1edfdb9b168153d2f6da2266e44d70562d8a7c0b6R8)