### PR TITLE
feat: Enhance CMake and build scripts with improved configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,17 @@ project(CLAVIS LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-# Collect Source Files
+# Set build type (default is Debug)
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
+# Basic compiler flags
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+endif()
+
+# Collect source files
 file(GLOB CORE_SOURCES
   src/*.cpp
   src/graph/*.hpp
@@ -12,7 +22,7 @@ file(GLOB CORE_SOURCES
   src/sorting/*.hpp
 )
 
-# Collect Test Files
+# Collect test files
 file(GLOB TEST_SOURCES
   tests/*.cpp
   tests/graph/*.cpp
@@ -20,25 +30,30 @@ file(GLOB TEST_SOURCES
   tests/sorting/*.cpp
 )
 
-# Integrate All Sources
+# Combine all sources
 set(SOURCES ${CORE_SOURCES})
 
-# Create Library
+# Create library
 add_library(clavis_algorithm ${SOURCES})
 
-# Google Test Setup
+# Set include directories
+target_include_directories(clavis_algorithm PUBLIC
+  ${CMAKE_SOURCE_DIR}/src
+)
+
+# Google Test configuration
 find_package(GTest REQUIRED)
 enable_testing()
 
-# Test Execution File
+# Test executable
 add_executable(clavis_algorithm_test ${TEST_SOURCES})
 
-# Include Directories
+# Set include directories for tests
 target_include_directories(clavis_algorithm_test PRIVATE
   ${CMAKE_SOURCE_DIR}/src
 )
 
 target_link_libraries(clavis_algorithm_test clavis_algorithm GTest::GTest GTest::Main)
 
-# Register Test
+# Register test
 add_test(NAME AlgorithmTest COMMAND clavis_algorithm_test)

--- a/scripts/build_debug.sh
+++ b/scripts/build_debug.sh
@@ -8,14 +8,16 @@ print_usage() {
   echo "Options:"
   echo "  -c, --clean     Remove old executable before building"
   echo "  -r, --run       Run program after building" 
+  echo "  -j, --jobs N    Compile with N parallel jobs (default: all cores)"
   echo "  -h, --help      Show this help message"
   echo ""
   echo "Example: $0 sort.cpp -r"
 }
 
-# Set default values 
+# Set default values
 CLEAN_MODE=0
 RUN_AFTER_BUILD=0
+NUM_JOBS=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)
 
 # Create build directory
 BUILD_DIR="build"
@@ -23,7 +25,7 @@ if [ ! -d "$BUILD_DIR" ]; then
   mkdir -p "$BUILD_DIR"
 fi
 
-# Show usage if no arguments
+# Show help if no arguments
 if [ $# -eq 0 ]; then
   print_usage
   exit 1
@@ -44,6 +46,14 @@ case "$1" in
     ;;
   -r|--run)
     RUN_AFTER_BUILD=1
+    ;;
+  -j|--jobs)
+    if [[ $2 =~ ^[0-9]+$ ]]; then
+      NUM_JOBS=$2
+      shift
+    else
+      NUM_JOBS=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)
+    fi
     ;;
   -h|--help)
     print_usage
@@ -66,12 +76,18 @@ fi
 
 # Run debug build
 echo "Building in debug mode..."
-g++ -std=c++20 -DDEBUG_LOG -g "$SOURCE_FILE" -o "$OUTPUT_FILE"
+g++ -std=c++20 -DDEBUG_LOG -g -Wall -Wextra "$SOURCE_FILE" -o "$OUTPUT_FILE"
 
-echo "Build complete: $OUTPUT_FILE"
+# Check build result
+if [ $? -eq 0 ]; then
+  echo "Build complete: $OUTPUT_FILE"
 
-# Run after build if requested
-if [ $RUN_AFTER_BUILD -eq 1 ]; then
-  echo "Running program..."
-  "$OUTPUT_FILE"
+  # Run after build (if requested)
+  if [ $RUN_AFTER_BUILD -eq 1 ]; then
+    echo "Running program..."
+    "$OUTPUT_FILE"
+  fi
+else
+  echo "Build failed."
+  exit 1
 fi

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-set -eux
+set -e  # Exit immediately if a command exits with a non-zero status
 
-# Create build directory if it doesn't exist
+# Create build directory (if it doesn't exist)
 if [ ! -d "build" ]; then
   mkdir build
 fi
@@ -14,8 +14,9 @@ cmake -DCMAKE_BUILD_TYPE=Debug \
       -DCMAKE_CXX_STANDARD_REQUIRED=ON \
       ..
 
-# Build
-cmake --build . -- -j"$(nproc)"
+# Build (using parallel build)
+JOBS=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)
+cmake --build . -- -j"$JOBS"
 
-# Run tests via CTest
+# Run tests
 GTEST_COLOR=1 ctest --verbose --output-on-failure


### PR DESCRIPTION
This pull request includes several changes to the build configuration and scripts for the project. The most important changes include setting the default build type to Debug, adding parallel job support for builds, and improving error handling in scripts.

Build configuration improvements:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL7-R58): Set the default build type to Debug and added basic compiler flags for GNU and Clang compilers. Also, organized and clarified comments for different sections.

Script enhancements:

* [`scripts/build_debug.sh`](diffhunk://#diff-15ac4bb4154d230bd7009f592f2be3fd903e84917c7f43b7a11f3419682aeac7R11): Added support for specifying the number of parallel jobs with the `-j` or `--jobs` option, and improved error handling by checking the build result and exiting if the build fails. [[1]](diffhunk://#diff-15ac4bb4154d230bd7009f592f2be3fd903e84917c7f43b7a11f3419682aeac7R11) [[2]](diffhunk://#diff-15ac4bb4154d230bd7009f592f2be3fd903e84917c7f43b7a11f3419682aeac7R20-R28) [[3]](diffhunk://#diff-15ac4bb4154d230bd7009f592f2be3fd903e84917c7f43b7a11f3419682aeac7R50-R57) [[4]](diffhunk://#diff-15ac4bb4154d230bd7009f592f2be3fd903e84917c7f43b7a11f3419682aeac7L69-R93)
* [`scripts/run_tests.sh`](diffhunk://#diff-e8dc6c83e649729e8adbbe07864f184105d21b7511ee421a35cd201a4821e0d2L2-R4): Modified the script to use parallel jobs for building and improved error handling by removing the `-x` option from `set` and adding a comment for creating the build directory. [[1]](diffhunk://#diff-e8dc6c83e649729e8adbbe07864f184105d21b7511ee421a35cd201a4821e0d2L2-R4) [[2]](diffhunk://#diff-e8dc6c83e649729e8adbbe07864f184105d21b7511ee421a35cd201a4821e0d2L17-R21)… parallel build support