### PR TITLE
build: migrate project to C++23

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -12,7 +12,7 @@
             ],
             "compilerPath": "/usr/bin/clang",
             "cStandard": "c17",
-            "cppStandard": "c++20",
+            "cppStandard": "c++23",
             "intelliSenseMode": "macos-clang-arm64"
         }
     ],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "C_Cpp.default.compilerPath": "/usr/bin/clang",
-  "C_Cpp.default.cppStandard": "c++20",
+  "C_Cpp.default.cppStandard": "c++23",
   "C_Cpp.default.includePath": [
     "${workspaceFolder}/src"
   ],

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ function(clavis_enable_warnings target)
 endfunction()
 
 add_library(clavis_algorithm)
-target_compile_features(clavis_algorithm PUBLIC cxx_std_20)
+target_compile_features(clavis_algorithm PUBLIC cxx_std_23)
 target_include_directories(clavis_algorithm PUBLIC
   ${PROJECT_SOURCE_DIR}/src
 )
@@ -97,7 +97,7 @@ if(CLANG_TIDY)
       ${CLAVIS_SOURCE_FILES}
       --
       -x c++
-      -std=c++20
+      -std=c++23
       -I${PROJECT_SOURCE_DIR}/src
     COMMENT "Running clang-tidy on source files"
     VERBATIM

--- a/README.md
+++ b/README.md
@@ -8,10 +8,13 @@ Welcome to Clavis! Here, efficient algorithms and unnecessarily complex C++ code
 
 | Tool | Version | Install (macOS) |
 |------|---------|-----------------|
+| C++ compiler | C++23 support | Xcode Command Line Tools |
 | CMake | 3.25+ | `brew install cmake` |
 | Ninja | any | `brew install ninja` |
 | GTest | any | `brew install googletest` |
-| LLVM | 16+ | `brew install llvm` |
+| LLVM | 17+ | `brew install llvm` |
+
+CI validates the project with GCC 13.
 
 ### Quick Setup (macOS)
 

--- a/scripts/build_debug.sh
+++ b/scripts/build_debug.sh
@@ -76,7 +76,7 @@ fi
 
 # Run debug build
 echo "Building in debug mode..."
-g++ -std=c++20 -DDEBUG_LOG -g -Wall -Wextra "$SOURCE_FILE" -o "$OUTPUT_FILE"
+g++ -std=c++23 -DDEBUG_LOG -g -Wall -Wextra "$SOURCE_FILE" -o "$OUTPUT_FILE"
 
 # Check build result
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
## Summary

- Require C++23 across CMake, clang-tidy, VS Code, and the debug build script
- Update the documented compiler and LLVM requirements

## Validation

- Built successfully with C++23
- All 94 tests pass
- Format and clang-tidy checks pass